### PR TITLE
Adjust deployment workflow

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -62,4 +62,4 @@ jobs:
         with:
           connectionString: ${{ secrets.RDAPI_RUBBERDUCKDB }}
           dacpac: '${{env.SOLUTION_FILE_PATH}}/artifacts/Rubberduck.Database.dacpac'
-          additionalArguments: '/p:BlockOnPossibleDataLoss=False'
+          additionalArguments: '/p:BlockOnPossibleDataLoss=False /p:ScriptDatabaseOptions=False'


### PR DESCRIPTION
`SqlPackage.exe` command must not script database options, because the remote user does not have `ALTER DATABASE` permission.